### PR TITLE
use async-await instead of blocking

### DIFF
--- a/PollyDemo.Client/CircuitBreaker/ApiClient.cs
+++ b/PollyDemo.Client/CircuitBreaker/ApiClient.cs
@@ -20,7 +20,7 @@ namespace PollyDemo.Client.CircuitBreaker
             this.httpClient.Dispose();
         }
 
-        public string SayHello(string name) 
-            => httpClient.GetStringAsync($"{this.baseUrl}api/sayhello/{name}").Result;
+        public async Task<string> SayHelloAsync(string name) 
+            => await httpClient.GetStringAsync($"{this.baseUrl}api/sayhello/{name}");
     }
 }

--- a/PollyDemo.Client/CircuitBreaker/IApiClient.cs
+++ b/PollyDemo.Client/CircuitBreaker/IApiClient.cs
@@ -1,7 +1,9 @@
-﻿namespace PollyDemo.Client.CircuitBreaker
+﻿using System.Threading.Tasks;
+
+namespace PollyDemo.Client.CircuitBreaker
 {
     interface IApiClient
     {
-        string SayHello(string name);
+        Task<string> SayHelloAsync(string name);
     }
 }

--- a/PollyDemo.Client/CircuitBreaker/ResilientApiClient.cs
+++ b/PollyDemo.Client/CircuitBreaker/ResilientApiClient.cs
@@ -2,6 +2,7 @@
 using Polly.CircuitBreaker;
 using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace PollyDemo.Client.CircuitBreaker
 {
@@ -16,7 +17,7 @@ namespace PollyDemo.Client.CircuitBreaker
             this.apiClient = new ApiClient(baseUrl);
 
             this.circuitBreaker = Policy
-                .HandleInner<HttpRequestException>()
+                .Handle<HttpRequestException>()
                 .CircuitBreaker(
                     exceptionsAllowedBeforeBreaking: 3,
                     durationOfBreak: TimeSpan.FromSeconds(5),
@@ -35,6 +36,6 @@ namespace PollyDemo.Client.CircuitBreaker
             this.apiClient.Dispose();
         }
 
-        public string SayHello(string name) => circuitBreaker.Execute(() => apiClient.SayHello(name));
+        public Task<string> SayHelloAsync(string name) => circuitBreaker.ExecuteAsync(async () => await apiClient.SayHelloAsync(name));
     }
 }

--- a/PollyDemo.Client/CircuitBreaker/ResilientRunner.cs
+++ b/PollyDemo.Client/CircuitBreaker/ResilientRunner.cs
@@ -21,7 +21,7 @@ namespace PollyDemo.Client.CircuitBreaker
                 try
                 {
                     Console.Write($"[{i:00}] ");
-                    string message = apiClient.SayHello("NetPonto");
+                    string message = apiClient.SayHelloAsync("NetPonto").GetAwaiter().GetResult();
                     Console.WriteLine($"server said \"{message}\"");
                 }
                 catch (BrokenCircuitException)

--- a/PollyDemo.Client/CircuitBreaker/Runner.cs
+++ b/PollyDemo.Client/CircuitBreaker/Runner.cs
@@ -18,7 +18,7 @@ namespace PollyDemo.Client.CircuitBreaker
                 try
                 {
                     Console.Write($"[{i:00}] ");
-                    string message = apiClient.SayHello("NetPonto");
+                    string message = apiClient.SayHelloAsync("NetPonto").GetAwaiter().GetResult();
                     Console.WriteLine($"server said \"{message}\"");
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Using `GetAwaiter().GetResult()` can cause deadlocks.

It might not happen on ASP.NET Core because it doesn't have a `SinchronizationContext` but it will happen on runtimes that have one.

Using `async`-`await` will also unwrap `AggregateException`s.